### PR TITLE
Update and rename error.php to errorHandle.php

### DIFF
--- a/application/controllers/errorHandle.php
+++ b/application/controllers/errorHandle.php
@@ -1,6 +1,6 @@
 <?php
 
-class Error extends Controller {
+class ErrorHandle extends Controller {
 	
 	function index()
 	{


### PR DESCRIPTION
change calss name from error to errorHandle. PHP 7 has reserved error keyword.